### PR TITLE
CI: Upgrade to Node.js v14.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v3.5.1
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - run: yarn install
       - run: yarn test


### PR DESCRIPTION
Looks like Node.js v12.x is no longer maintained... 😅 

see https://github.com/nodejs/release#release-schedule